### PR TITLE
Xbee frame should be dispatched to entries that match all frame types (0) or matches the current frame's type

### DIFF
--- a/include/xbee/device.h
+++ b/include/xbee/device.h
@@ -291,8 +291,8 @@ typedef void (*xbee_disc_node_id_fn)( struct xbee_dev_t *xbee,
 //@}
 
 typedef struct xbee_dispatch_table_entry {
-	uint8_t						frame_type;	///< if 0, match all frames
-	uint8_t						frame_id;	///< if 0, match all frames of this type
+	uint8_t						frame_type;	///< if 0, match all frames of this type
+	uint8_t						frame_id;	///< if 0, match all frames of this identifier
 	xbee_frame_handler_fn	handler;
 	void 					FAR	*context;
 } xbee_dispatch_table_entry_t;

--- a/src/xbee/xbee_device.c
+++ b/src/xbee/xbee_device.c
@@ -920,8 +920,9 @@ int _xbee_frame_dispatch( xbee_dev_t *xbee, const void FAR *frame,
 	dispatched = 0;
 	for (entry = xbee_frame_handlers; entry->frame_type != 0xFF; ++entry)
 	{
-		if (entry->frame_type == frametype)
+		if (! entry->frame_type || entry->frame_type == frametype)
 		{
+			// entry matches all frame types (0) or matches this frame's type
 			if (! entry->frame_id || entry->frame_id == frameid)
 			{
 				++dispatched;


### PR DESCRIPTION
As mentioned in the documentation: if the frame type equals 0 in the xbee_dispatch_table_entry, match all frames.
This allows users to have a handler that catches all incoming frames.
